### PR TITLE
CI housekeeping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,16 +16,16 @@ jobs:
       matrix:
         include:
           - elixir: "1.14"
-            otp: "24.2"
+            otp: "24"
             os: ubuntu-22.04
 
-          - elixir: "1.17"
-            otp: "27.0"
+          - elixir: "1.19"
+            otp: "28"
             lint: lint
             os: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: erlef/setup-beam@v1
         with:

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Plug.Crypto.MixProject do
     [
       app: :plug_crypto,
       version: @version,
-      elixir: "~> 1.11",
+      elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       package: package(),


### PR DESCRIPTION
Support Elixir 1.19 and OTP 28, bump actions/checkout, and set minimum Elixir requirements to 1.14 to tally with CI.